### PR TITLE
separate navlinks from regular links + detect external links

### DIFF
--- a/astro/src/components/Link.astro
+++ b/astro/src/components/Link.astro
@@ -1,23 +1,27 @@
 ---
 interface Props {
-    active?: boolean
     lower: boolean
     href: string
     text: string
 }
 
 const { 
-    active = true, 
     href, 
     text, 
-    lower
+    lower,
 } = Astro.props;
+
+// Pulled from 
+// https://stackoverflow.com/questions/10687099/how-to-test-if-a-url-string-is-absolute-or-relative
+var r = new RegExp('^(?:[a-z+]+:)?//', 'i');
+const isExternalLink = r.test(href)
 ---
 
 <a
     id={href}
     href={href}
-    class=`text-gray-600 hover:text-gray-500 ${active ? 'underline' : null} ${lower ? 'lowercase' : null}`
+    target={isExternalLink ? '_blank' : '_self'}
+    class=`text-gray-600 hover:text-gray-500 underline ${lower ? 'lowercase' : null}`
 >
     {text}
 </a>

--- a/astro/src/layouts/Layout.astro
+++ b/astro/src/layouts/Layout.astro
@@ -1,6 +1,6 @@
 ---
 import  SpeedInsights  from "@vercel/speed-insights/astro"
-import Link from '../components/Link.astro';
+import NavLink from '../components/NavLink.astro';
 
 interface Props {
     title: string
@@ -33,9 +33,9 @@ const { title, page } = Astro.props;
 			<div class="flex flex-row space-x-4 mr-4">
 				<p>Rohan Nagavardhan</p>
 				<div class="space-x-4">
-					<Link active={page === "about"} lower={true} href='/' text='About'/>
-					<Link active={page === "blog"} lower={true} href='/blog' text='Blog'/>
-					<Link active={page === "photos"} lower={true} href='/photos' text='Photos'/>
+					<NavLink active={page === "about"} href='/' text='About'/>
+					<NavLink active={page === "blog"}  href='/blog' text='Blog'/>
+					<NavLink active={page === "photos"} href='/photos' text='Photos'/>
 				</div>
 			</div>
 			<div class="mt-8">


### PR DESCRIPTION
scratching an itch.

i think i started to make the Link component a little too bloated. Separated out normal links and navlinks. The difference?

Nav links have an active prop, this will tell the page to render an underline if it is active
Links have the same interface as before, but now they'll actually detect if the href passed in is external and open it in a new tab if so :)

it's also smart enough to know if a relative href was provided, and avoid creating that new tab