### PR TITLE
Redesign album detail page with carousel and viewport-fit layout

### DIFF
--- a/astro/src/components/Photo.astro
+++ b/astro/src/components/Photo.astro
@@ -15,24 +15,23 @@ const url = urlFor(photo).url()
 const webpUrl = urlFor(photo).format('webp').url()
 ---
 
-<div class="group flex flex-col space-y-6 lg:max-w-5xl lg:flex-row lg:space-x-11 lg:space-y-0">
+<div>
     <picture>
-        <source
-            srcset={webpUrl}
-            type="image/webp"
-        />
+        <source srcset={webpUrl} type="image/webp" />
         <img
-            class="responsive__img max-h-[550px] max-w-xs lg:max-w-xl transition ease-in-out delay-750 group-hover:scale-[1.015]"
+            class="max-h-[calc(100dvh-16rem)] max-w-full sm:max-w-xs md:max-w-lg lg:max-w-xl"
             src={url}
             alt={alt}
         />
     </picture>
 
-    <div class="hidden max-w-xs leading-relaxed md:max-w-none md:leading-normal transition-ease-in-out delay-1000 group-hover:block space-y-5">
+    <div class="text-left space-y-2 mt-3 text-xs md:text-sm lg:text-base">
         <div>
             <p class="font-semibold">{title}</p>
-            <p class="text-xs italic">{location}</p>
+            <p class="italic">{location}</p>
         </div>
-        <PhotoDescription text={description}/>
+        <div class="hidden lg:block">
+            <PhotoDescription text={description}/>
+        </div>
     </div>
 </div>

--- a/astro/src/components/PhotoCarousel.astro
+++ b/astro/src/components/PhotoCarousel.astro
@@ -1,0 +1,62 @@
+---
+import Photo from "./Photo.astro"
+
+interface Props {
+   photos: any[];
+   class?: string;
+}
+
+const { photos, class: className } = Astro.props
+---
+
+<div id="photo-carousel" class:list={["flex flex-col", className]}>
+   <div class="flex-1 min-h-0 flex items-center justify-center">
+      {photos.map((photo, i) => (
+         <div class:list={["carousel-slide", { hidden: i !== 0 }]}>
+            <Photo node={photo}/>
+         </div>
+      ))}
+   </div>
+
+   <div class="flex items-center justify-center gap-4 mt-6 flex-shrink-0">
+      <button id="prev-btn" class="text-gray-400 cursor-not-allowed lowercase" disabled>prev</button>
+      <span id="carousel-counter" class="text-gray-500">1 / {photos.length}</span>
+      <button id="next-btn" class="text-gray-600 hover:text-gray-500 lowercase">next</button>
+   </div>
+</div>
+
+<script>
+   const slides = document.querySelectorAll('.carousel-slide');
+   const prevBtn = document.getElementById('prev-btn') as HTMLButtonElement;
+   const nextBtn = document.getElementById('next-btn') as HTMLButtonElement;
+   const counter = document.getElementById('carousel-counter')!;
+   const total = slides.length;
+   let current = 0;
+
+   function show(index: number) {
+      slides[current].classList.add('hidden');
+      current = index;
+      slides[current].classList.remove('hidden');
+      counter.textContent = `${current + 1} / ${total}`;
+
+      prevBtn.disabled = current === 0;
+      prevBtn.classList.toggle('text-gray-400', current === 0);
+      prevBtn.classList.toggle('cursor-not-allowed', current === 0);
+      prevBtn.classList.toggle('text-gray-600', current !== 0);
+      prevBtn.classList.toggle('hover:text-gray-500', current !== 0);
+
+      nextBtn.disabled = current === total - 1;
+      nextBtn.classList.toggle('text-gray-400', current === total - 1);
+      nextBtn.classList.toggle('cursor-not-allowed', current === total - 1);
+      nextBtn.classList.toggle('text-gray-600', current !== total - 1);
+      nextBtn.classList.toggle('hover:text-gray-500', current !== total - 1);
+   }
+
+   prevBtn.addEventListener('click', () => { if (current > 0) show(current - 1); });
+   nextBtn.addEventListener('click', () => { if (current < total - 1) show(current + 1); });
+
+   document.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft' && current > 0) show(current - 1);
+      if (e.key === 'ArrowRight' && current < total - 1) show(current + 1);
+   });
+</script>

--- a/astro/src/pages/albums/[...id].astro
+++ b/astro/src/pages/albums/[...id].astro
@@ -1,9 +1,8 @@
 ---
 // @ts-ignore
 import { sanityClient } from "sanity:client"
-import Photo from "../../components/Photo.astro"
+import PhotoCarousel from "../../components/PhotoCarousel.astro"
 import Layout from "../../layouts/Layout.astro"
-import SanityDescription from "../../components/SanityDescription.astro"
 
 export interface PhotoDocument {
    title: string,
@@ -34,19 +33,12 @@ export const getStaticPaths = (async () => {
    })
 })
 
-const {photos, title, description} = Astro.props
+const {photos, title} = Astro.props
 ---
 
-<Layout title=`Albums · ${title}`>
-   <a href="/photos" class="block text-gray-600 underline hover:no-underline lowercase">&lt; Back</a>
-
-   <div class="space-y-1 mt-10 mb-8 max-w-sm md:max-w-lg">
-      <p class="text-base font-bold">{title}</p>
-      <div class="italic"> 
-         <SanityDescription text={description}/>
-      </div>
-   </div>
-   <div class="max-w-sm" >
-      {photos.map((photo) => <Photo node={photo}/>)
+<Layout title=`Albums · ${title}`, page="photos">
+   <div class="flex flex-col h-[calc(100dvh-5rem)] overflow-hidden pr-5">
+      <a href="/photos" class="block text-gray-600 underline hover:no-underline lowercase">&lt; Back</a>
+      <PhotoCarousel photos={photos} class="flex-1 min-h-0" />
    </div>
 </Layout>


### PR DESCRIPTION
Replace the static photo list with a carousel, constrain images using viewport-relative max-height instead of flex-1/object-contain, and add responsive sizing for mobile, tablet, and desktop breakpoints.